### PR TITLE
Set channel mask according to hardcoded channel

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -167,6 +167,19 @@ ot-ctl dataset networkkey "$MASTER_KEY"
 ot-ctl dataset panid "$PANID"
 ot-ctl dataset extpanid "$XPANID"
 ot-ctl dataset channel "$CHANNEL"
+# Since 20/06/2021, the default OpenThread config (and therefore also the default border router
+# docker image) has Thread 1.2.1 "MLE Announce" turned on. This is a feature which announces the
+# presence of the network periodically on all channels in the active dataset's channel mask, but
+# has the consequence of making the router switch away from the active channel for a bit. If you
+# have sleepy end devices connected to the router, these may end up going to a detached state if
+# they attempt a data poll when the parent has switched away to announce on another channel.
+# To avoid this, set the channel mask for the border router such that only the configured channel
+# is allowed. This avoids the issue with the announce feature, but will prevent channel hopping
+# from taking place (which would be a very advanced use-case versus having sleepy devices in the
+# network).
+CHANNELMASK=$((2 ** $CHANNEL))
+CHANNELMASK=$(printf '0x%08x' $CHANNELMASK)
+ot-ctl dataset channelmask $CHANNELMASK
 ot-ctl dataset pskc "$PSKC"
 ot-ctl dataset commit active
 ot-ctl ifconfig up


### PR DESCRIPTION
Since a couple of days ago, the OpenThread codebase [has enabled Thread 1.2.1 "Announce" by default](https://github.com/openthread/openthread/pull/6741). This exposes an issue where if you have sleepy nodes attached to the border router, it could happen that the sleepy node's poll activity collides with an announce slot where the border router would switch away to a different channel in order to serve the MLE announce.

To avoid this, we can set the dataset to only enable the configured channel. This will prevent the network's nodes from switching away for announcing into thin air.