### PR TITLE
Fix critical errors and improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG MQTT_SN_COMMIT=f2dcda358f21e264de57b47b00ab6165bab4da18
 
-FROM ubuntu:18.04 AS build-mqtt
+FROM ubuntu:22.04 AS build-mqtt
 
 ARG MQTT_SN_COMMIT
 
@@ -25,3 +25,5 @@ COPY --from=build-mqtt /paho.mqtt-sn.embedded-c-"$MQTT_SN_COMMIT"/MQTTSNGateway/
 COPY --from=build-mqtt /paho.mqtt-sn.embedded-c-"$MQTT_SN_COMMIT"/build.gateway/MQTTSNPacket/src/libMQTTSNPacket.so /usr/local/lib/
 
 ADD docker_entrypoint.sh /app/etc/docker
+
+ENTRYPOINT ["/app/etc/docker/docker_entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The command line options with default values are shown in the following table.
 | PAN ID               |  --panid                        | 0xABCD                           |
 | Extended PAN ID      |  --xpanid                       | DEAD00BEEF00CAFE                 |
 | Channel              |  --channel                      | 11                               |
-| Network Key          |  --network-key                  | 00112233445566778899AABBCCDDEEFF |
+| Network Key          |  --master-key                   | 00112233445566778899AABBCCDDEEFF |
 | Network PSKc         |  --pskc                         | 5ce66d049d007088ad900dfcc2a55ee3 |
 | TUN Interface Name   |  --interface                    | wpan0                            |
 | NAT64 Prefix         |  --nat64-prefix                 | 64:ff9b::/96                     |

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -82,7 +82,7 @@ function parse_args()
             shift
             shift
             ;;
-        --masterkey-key)
+        --master-key)
             MASTER_KEY=$2
             shift
             shift
@@ -187,11 +187,11 @@ ot-ctl thread start
 
 # Set the address on which the MQTT-SN gateway needs to listen for discovery requests
 # Defaults to Thread's mesh-local "all nodes" address unless explicitly overridden
-MESH=$(ot-ctl dataset meshlocalprefix | sed -n 1p | sed 's/Mesh Local Prefix: //' | awk -F '::' '{print $1}')
+MESH=$(ot-ctl dataset meshlocalprefix | sed -n '1s/Mesh Local Prefix: //p' | awk -F '::' '{print $1}')
 [ -n "$MQTTSN_BROADCAST_ADDRESS" ] || MQTTSN_BROADCAST_ADDRESS="ff33:40:$MESH::1"
 sed -i "s/^GatewayUDP6Broadcast=.*$/GatewayUDP6Broadcast=$MQTTSN_BROADCAST_ADDRESS/" /app/gateway.conf
 
 echo "Starting MQTT-SN Gateway listening on: " $MQTTSN_BROADCAST_ADDRESS
-nohup 2>&1 /app/MQTT-SNGateway &
+nohup /app/MQTT-SNGateway > /var/log/mqtt-sn.log 2>&1 &
 
 tail -f /var/log/syslog


### PR DESCRIPTION
- Add missing ENTRYPOINT to Dockerfile to make container executable
- Fix parameter naming: change --masterkey-key to --master-key
- Update README.md to match corrected parameter name
- Upgrade base image from Ubuntu 18.04 to 22.04 for security
- Improve MQTT-SN gateway logging to redirect to /var/log/mqtt-sn.log
- Optimize sed command by combining operations

Fixes:
- Container now starts properly with default docker run commands
- Parameter consistency between script and documentation
- Uses supported Ubuntu version with security updates
- Better logging for debugging MQTT-SN gateway issues