### PR TITLE
Fix parameter name mismatches in docker_entrypoint.sh

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -82,12 +82,12 @@ function parse_args()
             shift
             shift
             ;;
-        --masterkey-key)
+        --network-key)
             MASTER_KEY=$2
             shift
             shift
             ;;
-        --psck)
+        --pskc)
             PSKC=$2
             shift
             shift


### PR DESCRIPTION
- Change --masterkey-key to --network-key to match README documentation
- Change --psck to --pskc to fix typo and match README documentation

These changes ensure that the command-line parameters in the script match the documentation in the README, allowing users to properly configure the network key and PSKc parameters.